### PR TITLE
docs: more consistent usage of node:fs

### DIFF
--- a/docs/modules/glob.md
+++ b/docs/modules/glob.md
@@ -19,9 +19,9 @@ const files = await glob('**/*.ts')
 
 Most options available to `glob` are available in `tinyglobby`, read more at the [tinyglobby documentation](https://superchupu.dev/tinyglobby/documentation).
 
-## `fs.glob` (native, since Node 22.x)
+## `fs.glob` and `fs.promises.glob` (native, Node.js)
 
-[`fs.glob`](https://nodejs.org/api/fs.html#fspromisesglobpattern-options) is built into modern versions of Node.
+Since Node 22 [`fs.glob`](https://nodejs.org/api/fs.html#fsglobpattern-options-callback) and [`fs.promises.glob`](https://nodejs.org/api/fs.html#fspromisesglobpattern-options) are built-in.
 
 Example:
 

--- a/docs/modules/mkdirp.md
+++ b/docs/modules/mkdirp.md
@@ -4,24 +4,18 @@ description: Modern alternatives to the mkdirp and make-dir packages for recursi
 
 # Replacements for `mkdirp` / `make-dir`
 
-## Recursive `fs.mkdir` (native, since Node.js v10.12.0)
+## Recursive `fs.mkdir` and `fs.promises.mkdir` (native, Node.js)
 
-Node.js v10.12.0 and up supports the `recursive` option in the [`fs.mkdir`](https://nodejs.org/api/fs.html#fsmkdirpath-options-callback) function, which allows parent directories to be created automatically.
+Node.js v10.12.0 and up supports the `recursive` option in the [`fs.mkdir`](https://nodejs.org/api/fs.html#fsmkdirpath-options-callback) and [`fs.promises.mkdir`](https://nodejs.org/api/fs.html#fspromisesmkdirpath-options) functions, which allows parent directories to be created automatically.
 
 Example migration from [`mkdirp`](https://github.com/isaacs/node-mkdirp):
 
 ```ts
 import { mkdirp } from 'mkdirp' // [!code --]
-import { mkdir, mkdirSync } from 'node:fs' // [!code ++]
-import { mkdir as mkdirAsync } from 'node:fs/promises' // [!code ++]
+import { mkdir } from 'node:fs/promises' // [!code ++]
 
-// Async
 await mkdirp('/tmp/foo/bar/baz') // [!code --]
-await mkdirAsync('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
-
-// Sync
-mkdirp.sync('/tmp/foo/bar/baz') // [!code --]
-mkdirSync('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
+await mkdir('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
 ```
 
 Example migration from [`make-dir`](https://github.com/sindresorhus/make-dir):

--- a/docs/modules/mkdirp.md
+++ b/docs/modules/mkdirp.md
@@ -12,22 +12,28 @@ Example migration from [`mkdirp`](https://github.com/isaacs/node-mkdirp):
 
 ```ts
 import { mkdirp } from 'mkdirp' // [!code --]
+import { mkdirSync } from 'node:fs' // [!code ++]
 import { mkdir } from 'node:fs/promises' // [!code ++]
 
+// Async
 await mkdirp('/tmp/foo/bar/baz') // [!code --]
 await mkdir('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
+
+// Sync
+mkdirp.sync('/tmp/foo/bar/baz') // [!code --]
+mkdirSync('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
 ```
 
 Example migration from [`make-dir`](https://github.com/sindresorhus/make-dir):
 
 ```ts
 import { makeDirectory, makeDirectorySync } from 'make-dir' // [!code --]
-import { mkdir, mkdirSync } from 'node:fs' // [!code ++]
-import { mkdir as mkdirAsync } from 'node:fs/promises' // [!code ++]
+import { mkdirSync } from 'node:fs' // [!code ++]
+import { mkdir } from 'node:fs/promises' // [!code ++]
 
 // Async
 await makeDirectory('/tmp/foo/bar/baz') // [!code --]
-await mkdirAsync('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
+await mkdir('/tmp/foo/bar/baz', { recursive: true }) // [!code ++]
 
 // Sync
 makeDirectorySync('/tmp/foo/bar/baz') // [!code --]

--- a/docs/modules/path-exists.md
+++ b/docs/modules/path-exists.md
@@ -4,9 +4,9 @@ description: Modern alternatives to the path-exists package for checking if a pa
 
 # Replacements for `path-exists`
 
-## Async `fs.access` (native, Node.js)
+## `fs.access` and `fs.promises.access` (native, Node.js)
 
-Use [`fs/promises.access`](https://nodejs.org/docs/latest/api/fs.html#fspromisesaccesspath-mode) and return a boolean.
+Use [`fs.promises.access`](https://nodejs.org/docs/latest/api/fs.html#fspromisesaccesspath-mode) and return a boolean.
 
 <!-- prettier-ignore -->
 ```ts

--- a/docs/modules/rimraf.md
+++ b/docs/modules/rimraf.md
@@ -4,7 +4,7 @@ description: Native Node.js alternatives to the rimraf package for recursive dir
 
 # Replacements for `rimraf`
 
-## `fs.rm` (native, Node.js)
+## `fs.rmSync` and `fs.promises.rm` (native, Node.js)
 
 Node.js v14.14.0 and above provide a native alternative: [`fs.rm`](https://nodejs.org/api/fs.html#fspromisesrmpath-options) and [`fs.rmSync`](https://nodejs.org/api/fs.html#fsrmsyncpath-options). It supports recursive deletion and works as a direct replacement.
 
@@ -13,19 +13,15 @@ Node.js v14.14.0 and above provide a native alternative: [`fs.rm`](https://nodej
 ```ts
 import rimraf from 'rimraf' // [!code --]
 import { rm } from 'node:fs/promises' // [!code ++]
+import { rmSync } from 'node:fs' // [!code ++]
 
+// Async
 await rimraf('./dist') // [!code --]
 await rm('./dist', { recursive: true, force: true }) // [!code ++]
-```
 
-### Sync methods
-
-```ts
-import rimraf from 'rimraf' // [!code --]
-import * as fs from 'node:fs' // [!code ++]
-
+// Sync
 rimraf.sync('./dist') // [!code --]
-fs.rmSync('./dist', { recursive: true, force: true }) // [!code ++]
+rmSync('./dist', { recursive: true, force: true }) // [!code ++]
 ```
 
 > [!IMPORTANT]

--- a/docs/modules/tempy.md
+++ b/docs/modules/tempy.md
@@ -4,9 +4,9 @@ description: Modern alternatives to the temp and tempy packages for creating tem
 
 # Replacements for `temp` / `tempy`
 
-## `fs.mkdtemp` (native, since Node.js v14.x)
+## `fs.mkdtemp` and `fs.promises.mkdtemp` (native, since Node.js v14.x)
 
-Node.js has the [`fs.mkdtemp`](https://nodejs.org/api/fs.html#fsmkdtempprefix-options-callback) function for creating a unique temporary directory. Directory cleanup can be done by passing `{recursive: true}` to [`fs.rm`](https://nodejs.org/api/fs.html#fsrmpath-options-callback).
+Node.js has the [`fs.mkdtemp`](https://nodejs.org/api/fs.html#fsmkdtempprefix-options-callback) and [`fs.promises.mkdtemp`](https://nodejs.org/api/fs.html#fspromisesmkdtempprefix-options) functions for creating a unique temporary directory. Directory cleanup can be done by passing `{recursive: true}` to [`fs.rm`](https://nodejs.org/api/fs.html#fsrmpath-options-callback).
 
 Example:
 
@@ -20,9 +20,9 @@ const tempDirPath = temp.mkdirSync('foo') // [!code --]
 const tempDirPath = await mkdtemp(join(await realpath(tmpdir()), 'foo-')) // [!code ++]
 ```
 
-## `fs.mkdtempDisposable` (native, since Node.js v20.4.0)
+## `fs.promises.mkdtempDisposable` (native, since Node.js v20.4.0)
 
-Node.js now provides [`fs.mkdtempDisposable`](https://nodejs.org/api/fs.html#fspromisesmkdtempdisposableprefix-options) which leverages the `using` keyword for automatic cleanup. This eliminates the need for `temp.track()` or manual cleanup logic.
+Node.js now provides [`fs.promises.mkdtempDisposable`](https://nodejs.org/api/fs.html#fspromisesmkdtempdisposableprefix-options) which leverages the `using` keyword for automatic cleanup. This eliminates the need for `temp.track()` or manual cleanup logic.
 
 Example:
 


### PR DESCRIPTION
I tried to make the `node:fs` related docs more consistent with each other - kinda follow up from #687