### PR TITLE
docs(dotenv): suggest process.loadEnvFile as native replacement

### DIFF
--- a/docs/modules/dotenv.md
+++ b/docs/modules/dotenv.md
@@ -4,9 +4,9 @@ description: Native Node.js alternatives to the dotenv package for loading and m
 
 # Replacements for `dotenv`
 
-## Node.js `process.loadEnvFile`
+## `process.loadEnvFile` (native, since Node.js v20.12.0)
 
-[`process.loadEnvFile`](https://nodejs.org/docs/latest-v20.x/api/process.html#processloadenvfilepath) (Node.js v20.12.0+) loads a `.env` file into `process.env` at runtime. It is the closest drop-in replacement for `dotenv.config()` when you need to load environment variables programmatically instead of via the `--env-file` flag.
+[`process.loadEnvFile`](https://nodejs.org/api/process.html#processloadenvfilepath) (Node.js v20.12.0+) loads a `.env` file into `process.env` at runtime.
 
 It throws if the file is missing. Defaults to `.env` in the current working directory when called without a path.
 

--- a/docs/modules/dotenv.md
+++ b/docs/modules/dotenv.md
@@ -4,6 +4,19 @@ description: Native Node.js alternatives to the dotenv package for loading and m
 
 # Replacements for `dotenv`
 
+## Node.js `process.loadEnvFile`
+
+[`process.loadEnvFile`](https://nodejs.org/docs/latest-v20.x/api/process.html#processloadenvfilepath) (Node.js v20.12.0+) loads a `.env` file into `process.env` at runtime. It is the closest drop-in replacement for `dotenv.config()` when you need to load environment variables programmatically instead of via the `--env-file` flag.
+
+It throws if the file is missing. Defaults to `.env` in the current working directory when called without a path.
+
+```ts
+import dotenv from 'dotenv' // [!code --]
+
+dotenv.config({ path: '.env' }) // [!code --]
+process.loadEnvFile('.env') // [!code ++]
+```
+
 ## `--env-file` / `--env-file-if-exists` (native, Node.js)
 
 [`--env-file`](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--env-fileconfig) (Node.js v20.6.0+) and [`--env-file-if-exists`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--env-file-if-existsfile) (Node.js v22.9.0+) can be passed as command-line flags to load environment variables from a specified file.

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -247,7 +247,7 @@
     "dotenv": {
       "type": "module",
       "moduleName": "dotenv",
-      "replacements": ["--env-file"],
+      "replacements": ["process.loadEnvFile", "--env-file"],
       "url": {"type": "e18e", "id": "dotenv"}
     },
     "dottie": {
@@ -3493,6 +3493,11 @@
       "id": "premove",
       "type": "documented",
       "replacementModule": "premove"
+    },
+    "process.loadEnvFile": {
+      "id": "process.loadEnvFile",
+      "type": "native",
+      "url": {"type": "node", "id": "api/process.html#processloadenvfilepath"}
     },
     "react-helmet-async": {
       "id": "react-helmet-async",


### PR DESCRIPTION
## What

Adds [`process.loadEnvFile(path)`](https://nodejs.org/docs/latest-v20.x/api/process.html#processloadenvfilepath) (Node.js v20.12.0+) as the first suggested native replacement in the `dotenv` docs.

It is the closest drop-in for `dotenv.config()` when env vars must be loaded programmatically rather than via the `--env-file` flag.

## Verified

Behavior claims checked empirically on Node v24.16.0:

- Throws `ENOENT` when the file is missing.
- Defaults to `.env` in the current working directory when called with no path.

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)