### PR TITLE
feat: remove commander

### DIFF
--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -144,12 +144,6 @@
       "replacements": ["util.styleText", "picocolors", "ansis"],
       "url": {"type": "e18e", "id": "chalk"}
     },
-    "commander": {
-      "type": "module",
-      "moduleName": "commander",
-      "replacements": ["sade", "cleye"],
-      "url": {"type": "e18e", "id": "cli-builders"}
-    },
     "copy-text-to-clipboard": {
       "type": "module",
       "moduleName": "copy-text-to-clipboard",


### PR DESCRIPTION
### 🔗 Linked issue

Reference: https://github.com/e18e/module-replacements/issues/772#issuecomment-4885874954

### 📚 Description

Commander is feature rich, but not as crufty or as slow as perhaps assumed. A simple download size comparison with the suggested replacements is misleading, because `commander` ships unminified code while both `sade` and `cleye` ship minified code. Commander is also the first to go esm-only.

Looking at package download size against the suggested replacements, measured using `npx download-size package-name`. (Also built a local minified commander for comparison.)

| package | version | size |
| ------- | ------- | ----: |
| sade | 1.8.1 | 14.55 KiB |
| commander-minified | 15.0.0 | ~31 KiB|
| commander | 15.0.0 | 51.50 KiB |
| cleye | 2.6.0 | 61.72 KiB |

And total runtime for parsing sample arguments with a boolean option, option with option-argument, and positional.

```
const argsFromNode = ['node', 'dummy.js', '-b', '--value', 'VALUE', 'ARGUMENT'];
```

| package | version | total time |
| ------- | ------- | ---------- |
| empty file | | 29.4 ms ±   1.1 ms |
| node:util parseArgs | 24.18.0 | 30.3 ms ±   0.9 ms |
| sade | 1.8.1 | 30.4 ms ±   1.0 ms |
| commander-minified | 15.0.0 | 35.1 ms ±   1.1 ms |
| commander | 15.0.0 | 37.1 ms ±   0.9 ms |
| cleye | 2.6.0 | 43.0 ms ±   0.8 ms |

-----

For potential for savings, @43081j  noted:

> commander just has a lot of necessary code for the features it provides. the only real way to trim it down is to drop the lesser used features one day, really.

Separate comments and discussion noted that there is potential for reducing size of Commander download by trimming README, moving less used features out into separate documents. That is something I'll look at in future.
