### PR TITLE
feat: add @libsql/client as a replacement for sqlite3

### DIFF
--- a/docs/modules/sqlite3.md
+++ b/docs/modules/sqlite3.md
@@ -37,3 +37,20 @@ const db = new Database('app.db') // [!code ++]
 db.all('SELECT * FROM users', (err, rows) => {}) // [!code --]
 const rows = db.prepare('SELECT * FROM users').all() // [!code ++]
 ```
+
+## `@libsql/client`
+
+[`@libsql/client`](https://github.com/tursodatabase/libsql-client-ts) is a modern, promise-based client that is fully compatible with SQLite. It supports local SQLite files, remote LibSQL servers, and Turso databases, making it easy to transition to the edge in the future.
+
+Example:
+
+```ts
+import sqlite3 from 'sqlite3' // [!code --]
+import { createClient } from '@libsql/client' // [!code ++]
+
+const db = new sqlite3.Database('app.db') // [!code --]
+const db = createClient({ url: 'file:app.db' }) // [!code ++]
+
+db.all('SELECT * FROM users', (err, rows) => {}) // [!code --]
+const { rows } = await db.execute('SELECT * FROM users') // [!code ++]
+```

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2593,7 +2593,7 @@
     "sqlite3": {
       "type": "module",
       "moduleName": "sqlite3",
-      "replacements": ["node:sqlite", "better-sqlite3"],
+      "replacements": ["node:sqlite", "better-sqlite3", "@libsql/client"],
       "url": {"type": "e18e", "id": "sqlite3"}
     },
     "stream-buffers": {
@@ -2823,6 +2823,11 @@
       "id": "@fastify/deepmerge",
       "type": "documented",
       "replacementModule": "@fastify/deepmerge"
+    },
+    "@libsql/client": {
+      "id": "@libsql/client",
+      "type": "documented",
+      "replacementModule": "@libsql/client"
     },
     "@material/web": {
       "id": "@material/web",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #836

### 📚 Description

Add `@libsql/client` as a replacement for `sqlite3`.

Drizzle docs for get-started-sqlite now lists @libsql/client as the first (primary) driver before better-sqlite3, so this library is gaining a lot of traction.