### PR TITLE
feat(preferred): add which-pm

### DIFF
--- a/docs/modules/detect-package-manager.md
+++ b/docs/modules/detect-package-manager.md
@@ -1,5 +1,5 @@
 ---
-description: Lightweight alternative to detect-package-manager for detecting the package manager with zero subdependencies
+description: Lightweight alternative to detect-package-manager for detecting the package manager with zero dependencies
 ---
 
 # Replacements for `detect-package-manager`
@@ -8,13 +8,9 @@ description: Lightweight alternative to detect-package-manager for detecting the
 
 [`package-manager-detector`](https://github.com/antfu-collective/package-manager-detector) is a lightweight alternative for detecting the package manager being used in a project.
 
-### Key differences
+It has zero dependencies, is ESM-only, and provides utilities such as constructing commands for different package managers.
 
-- **Zero subdependencies** compared to 16 in `detect-package-manager`
-- **ESM-only**, while `detect-package-manager` is primarily CJS (with ESM support)
-- **Smaller bundle size** due to the lack of dependencies
-
-### Migration example
+Example migration from [`detect-package-manager`](https://www.npmjs.com/package/detect-package-manager):
 
 ```ts
 import { detect } from 'detect-package-manager' // [!code --]
@@ -28,4 +24,32 @@ const pm = result?.name // [!code ++]
 > [!NOTE]
 > `package-manager-detector` returns an object with `name` and `agent` properties, while `detect-package-manager` returns a string directly.
 
-Both packages can detect npm, yarn, pnpm, and bun package managers in your project by analyzing lock files. Additionally, `package-manager-detector` also supports deno.
+Example migration from [`preferred-pm`](https://www.npmjs.com/package/preferred-pm):
+
+```ts
+import { preferredPM } from 'preferred-pm' // [!code --]
+import { detect } from 'package-manager-detector' // [!code ++]
+
+const result = await preferredPM() // [!code --]
+const result = await detect() // [!code ++]
+```
+
+Example migration from [`which-pm`](https://www.npmjs.com/package/which-pm):
+
+<!-- prettier-ignore -->
+```ts
+import { whichPM } from 'which-pm' // [!code --]
+import { detect } from 'package-manager-detector' // [!code ++]
+
+const result = await whichPM() // [!code --]
+const result = await detect({ // [!code ++]
+  // Include the `install-metadata` strategy to have the package manager // [!code ++]
+  // that's used for installation take precedence // [!code ++]
+  strategies: [ // [!code ++]
+    'install-metadata', // [!code ++]
+    'lockfile', // [!code ++]
+    'packageManager-field', // [!code ++]
+    'devEngines-field' // [!code ++]
+  ] // [!code ++]
+}) // [!code ++]
+```

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2762,6 +2762,12 @@
       "replacements": ["fetch", "ofetch", "ky"],
       "url": {"type": "e18e", "id": "fetch"}
     },
+    "which-pm": {
+      "type": "module",
+      "moduleName": "which-pm",
+      "replacements": ["package-manager-detector"],
+      "url": {"type": "e18e", "id": "detect-package-manager"}
+    },
     "wrap-ansi": {
       "type": "module",
       "moduleName": "wrap-ansi",


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 📚 Description

`which-pm` has dependencies issue: https://npmgraph.js.org/?q=which-pm

`which-pm` is similar to `preferred-pm` (which is already in the manifest). The main difference is that `which-pm` prioritizes checking the installation metadata first before checking the lockfiles. This may be important for steps that wants to install dependencies.

I've also updated the markdown explanation to better clarify the benefits generally, and specific migration guides for the packages we're replacing.

I've changed this in the past [for Astro](https://github.com/withastro/astro/blob/0a79753610ff4960ae6c9e6e334115f6ea0bc954/packages/astro/src/cli/install-package.ts#L65-L70). The main requirement is to specify the `strategies` option to prioritize checking install-metadata first. This is also documented in the [`package-manager-detector` readme](https://github.com/antfu-collective/package-manager-detector#customize-detection-strategy).