### PR TITLE
feat: add object rest spread Babel plugin removals

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -72,33 +72,6 @@
         "compatKey": "javascript.builtins.TypedArray.slice"
       }
     },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "id": "@babel/plugin-proposal-object-rest-spread",
-      "type": "removal",
-      "description": "Object rest/spread syntax is supported in all modern environments, so this Babel plugin is no longer needed.",
-      "url": {
-        "type": "mdn",
-        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
-      }
-    },
-    "@babel/plugin-syntax-object-rest-spread": {
-      "id": "@babel/plugin-syntax-object-rest-spread",
-      "type": "removal",
-      "description": "Object rest/spread syntax is supported in all modern environments, so this Babel plugin is no longer needed.",
-      "url": {
-        "type": "mdn",
-        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
-      }
-    },
-    "@babel/plugin-transform-object-rest-spread": {
-      "id": "@babel/plugin-transform-object-rest-spread",
-      "type": "removal",
-      "description": "Object rest/spread syntax is supported in all modern environments, so this Babel plugin is no longer needed.",
-      "url": {
-        "type": "mdn",
-        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
-      }
-    },
     "AbortController": {
       "id": "AbortController",
       "type": "native",
@@ -1893,6 +1866,18 @@
       "description": "All modern versions of Node have `Buffer.from` for safely creating buffers from arbitrary types.",
       "url": {"type": "node", "id": "api/buffer.html"}
     },
+    "spread_syntax": {
+      "id": "spread_syntax",
+      "type": "native",
+      "url": {
+        "type": "mdn",
+        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
+      },
+      "webFeatureId": {
+        "featureId": "object-object",
+        "compatKey": "javascript.operators.object_initializer.spread_properties"
+      }
+    },
     "string_decoder": {
       "id": "string_decoder",
       "type": "native",
@@ -1930,17 +1915,17 @@
     "@babel/plugin-proposal-object-rest-spread": {
       "type": "module",
       "moduleName": "@babel/plugin-proposal-object-rest-spread",
-      "replacements": ["@babel/plugin-proposal-object-rest-spread"]
+      "replacements": ["spread_syntax"]
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "type": "module",
       "moduleName": "@babel/plugin-syntax-object-rest-spread",
-      "replacements": ["@babel/plugin-syntax-object-rest-spread"]
+      "replacements": ["spread_syntax"]
     },
     "@babel/plugin-transform-object-rest-spread": {
       "type": "module",
       "moduleName": "@babel/plugin-transform-object-rest-spread",
-      "replacements": ["@babel/plugin-transform-object-rest-spread"]
+      "replacements": ["spread_syntax"]
     },
     "abort-controller": {
       "type": "module",

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -72,6 +72,33 @@
         "compatKey": "javascript.builtins.TypedArray.slice"
       }
     },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "id": "@babel/plugin-proposal-object-rest-spread",
+      "type": "removal",
+      "description": "Object rest/spread syntax is supported in all modern environments, so this Babel plugin is no longer needed.",
+      "url": {
+        "type": "mdn",
+        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "id": "@babel/plugin-syntax-object-rest-spread",
+      "type": "removal",
+      "description": "Object rest/spread syntax is supported in all modern environments, so this Babel plugin is no longer needed.",
+      "url": {
+        "type": "mdn",
+        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
+      }
+    },
+    "@babel/plugin-transform-object-rest-spread": {
+      "id": "@babel/plugin-transform-object-rest-spread",
+      "type": "removal",
+      "description": "Object rest/spread syntax is supported in all modern environments, so this Babel plugin is no longer needed.",
+      "url": {
+        "type": "mdn",
+        "id": "Web/JavaScript/Reference/Operators/Spread_syntax"
+      }
+    },
     "AbortController": {
       "id": "AbortController",
       "type": "native",
@@ -1900,6 +1927,21 @@
     }
   },
   "mappings": {
+    "@babel/plugin-proposal-object-rest-spread": {
+      "type": "module",
+      "moduleName": "@babel/plugin-proposal-object-rest-spread",
+      "replacements": ["@babel/plugin-proposal-object-rest-spread"]
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "type": "module",
+      "moduleName": "@babel/plugin-syntax-object-rest-spread",
+      "replacements": ["@babel/plugin-syntax-object-rest-spread"]
+    },
+    "@babel/plugin-transform-object-rest-spread": {
+      "type": "module",
+      "moduleName": "@babel/plugin-transform-object-rest-spread",
+      "replacements": ["@babel/plugin-transform-object-rest-spread"]
+    },
     "abort-controller": {
       "type": "module",
       "moduleName": "abort-controller",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Closes #850 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Adds removal mappings for the Babel plugins associated with object rest/spread syntax.

These plugins are redundant for modern targets, where object rest/spread is supported natively.
<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
