### PR TITLE
feat: add clone-deep native replacement

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2157,6 +2157,11 @@
       "moduleName": "buffer-from",
       "replacements": ["Buffer.from"]
     },
+    "clone-deep": {
+      "type": "module",
+      "moduleName": "clone-deep",
+      "replacements": ["structuredClone"]
+    },
     "collection-map": {
       "type": "module",
       "moduleName": "collection-map",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Closes #876


### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Adds `structuredClone()` as the native replacement for `clone-deep`.

`structuredClone()` is already defined in the native manifest with its MDN reference and compatibility metadata, so this change reuses the existing replacement entry.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
