### PR TITLE
feat: add yaml-ast-parser replacement

### DIFF
--- a/docs/modules/yaml-ast-parser.md
+++ b/docs/modules/yaml-ast-parser.md
@@ -1,0 +1,24 @@
+---
+description: Modern alternatives to yaml-ast-parser for parsing YAML into an AST
+---
+
+# Replacements for `yaml-ast-parser`
+
+## `yaml`
+
+[`yaml`](https://github.com/eemeli/yaml) is an actively maintained YAML parser with support for YAML 1.1 and 1.2, comments, and AST access.
+
+`yaml-ast-parser` returns a `YAMLNode` from `load`. With `yaml`, use `parseDocument` and access the root node through `document.contents`.
+
+Example:
+
+```ts
+import { load } from 'yaml-ast-parser' // [!code --]
+import { parseDocument } from 'yaml' // [!code ++]
+
+const ast = load(source) // [!code --]
+const document = parseDocument(source) // [!code ++]
+const ast = document.contents // [!code ++]
+```
+
+The AST node types differ between the two packages, so code that traverses or modifies nodes will need to use the node APIs provided by `yaml`.

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2780,6 +2780,11 @@
       "replacements": ["@xmldom/xmldom"],
       "url": {"type": "e18e", "id": "xmldom"}
     },
+    "yaml-ast-parser": {
+      "type": "module",
+      "moduleName": "yaml-ast-parser",
+      "replacements": ["yaml"]
+    },
     "yamljs": {
       "type": "module",
       "moduleName": "yamljs",

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2783,7 +2783,8 @@
     "yaml-ast-parser": {
       "type": "module",
       "moduleName": "yaml-ast-parser",
-      "replacements": ["yaml"]
+      "replacements": ["yaml"],
+      "url": {"type": "e18e", "id": "yaml-ast-parser"}
     },
     "yamljs": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Closes #841

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Maps the unmaintained yaml-ast-parser package to yaml, which is actively maintained and provides native support for parsing YAML into an AST.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
