### PR TITLE
feat: add `dev-null` to preferred replacements

### DIFF
--- a/docs/modules/dev-null.md
+++ b/docs/modules/dev-null.md
@@ -1,0 +1,25 @@
+---
+description: Modern alternatives to the dev-null package
+---
+
+# Replacements for `dev-null`
+
+## `stream.Writable` (native, Node.js)
+
+The native [`stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable) class can be used to construct a custom writable stream that discards incoming data.
+
+<!-- prettier-ignore -->
+```ts
+import devnull from 'dev-null' // [!code --]
+import { Writable } from 'node:stream' // [!code ++]
+
+stream.pipe(devnull()) // [!code --]
+
+const empty = new Writable({ // [!code ++]
+  write(chunk, encoding, callback) { // [!code ++]
+    callback() // [!code ++]
+  } // [!code ++]
+}) // [!code ++]
+
+stream.pipe(empty) // [!code ++]
+```

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -244,6 +244,12 @@
       "replacements": ["package-manager-detector"],
       "url": {"type": "e18e", "id": "detect-package-manager"}
     },
+    "dev-null": {
+      "type": "module",
+      "moduleName": "dev-null",
+      "replacements": ["node:stream"],
+      "url": {"type": "e18e", "id": "dev-null"}
+    },
     "dot-prop": {
       "type": "module",
       "moduleName": "dot-prop",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #863


### 📚 Description

Ideally we should put this in `native` manifest probably, but I've put it here for now, since that's what `through` and other also do