### PR TITLE
docs: add pnpm regex script matching as alternative to npm-run-all

### DIFF
--- a/docs/modules/npm-run-all.md
+++ b/docs/modules/npm-run-all.md
@@ -86,3 +86,27 @@ If you are using bun you can use [`bun run --parallel`](https://bun.com/docs/run
   }
 }
 ```
+
+
+## `pnpm run "/<regex>/"`
+
+If you are using pnpm you can use [regex script matching](https://pnpm.io/cli/run#running-multiple-scripts) to run multiple scripts at once. Wrap the regex in quotes so the shell does not mangle it.
+
+```json
+{
+  "scripts": {
+    "dev": "npm-run-all --parallel \"dev:*\"", // [!code --]
+    "dev": "pnpm run \"/^dev:.*/\"" // [!code ++]
+  }
+}
+```
+
+To run them sequentially instead of in parallel, add [`--sequential`](https://pnpm.io/cli/run#--sequential--s):
+
+```json
+{
+  "scripts": {
+    "build": "pnpm run --sequential \"/^build:.*/\""
+  }
+}
+```

--- a/docs/modules/npm-run-all.md
+++ b/docs/modules/npm-run-all.md
@@ -87,7 +87,6 @@ If you are using bun you can use [`bun run --parallel`](https://bun.com/docs/run
 }
 ```
 
-
 ## `pnpm run "/<regex>/"`
 
 If you are using pnpm you can use [regex script matching](https://pnpm.io/cli/run#running-multiple-scripts) to run multiple scripts at once. Wrap the regex in quotes so the shell does not mangle it.


### PR DESCRIPTION
### 🔗 Linked issue
/ 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
refer to https://pnpm.io/cli/run#running-multiple-scripts
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
