### PR TITLE
feat: add es6-promisify native replacement

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2546,6 +2546,11 @@
       "moduleName": "es6-promise",
       "replacements": ["Promise"]
     },
+    "es6-promisify": {
+      "type": "module",
+      "moduleName": "es6-promisify",
+      "replacements": ["util.promisify"]
+    },
     "es6-set": {
       "type": "module",
       "moduleName": "es6-set",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #970

### 📚 Description

Maps `es6-promisify` to the existing native `util.promisify` replacement.