### PR TITLE
feat: replace mktemp with native alternatives

### DIFF
--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2372,6 +2372,16 @@
       "replacements": ["fs.promises.mkdir"],
       "url": {"type": "e18e", "id": "mkdirp"}
     },
+    "mktemp": {
+      "type": "module",
+      "moduleName": "mktemp",
+      "replacements": [
+        "fs.promises.mkdtempDisposable",
+        "fs.promises.mkdtemp",
+        "Deno.makeTempDir"
+      ],
+      "url": {"type": "e18e", "id": "tempy"}
+    },
     "mockdate": {
       "type": "module",
       "moduleName": "mockdate",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #967

### 📚 Description

Adds `mktemp` to the preferred replacements manifest, using the same native alternatives and migration guidance as `tempy`.