### PR TITLE
fix: move `stream.Duplex` to native manifest

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2038,6 +2038,12 @@
         "compatKey": "javascript.operators.object_initializer.spread_properties"
       }
     },
+    "stream.Duplex": {
+      "id": "stream.Duplex",
+      "type": "native",
+      "url": {"type": "node", "id": "api/stream.html#class-streamduplex"},
+      "nodeFeatureId": {"moduleName": "node:stream", "exportName": "Duplex"}
+    },
     "string_decoder": {
       "id": "string_decoder",
       "type": "native",
@@ -2460,6 +2466,30 @@
       "moduleName": "desm",
       "replacements": ["import.meta"],
       "url": {"type": "e18e", "id": "desm"}
+    },
+    "duplexer": {
+      "type": "module",
+      "moduleName": "duplexer",
+      "replacements": ["stream.Duplex"],
+      "url": {"type": "e18e", "id": "duplexer"}
+    },
+    "duplexer2": {
+      "type": "module",
+      "moduleName": "duplexer2",
+      "replacements": ["stream.Duplex"],
+      "url": {"type": "e18e", "id": "duplexer"}
+    },
+    "duplexer3": {
+      "type": "module",
+      "moduleName": "duplexer3",
+      "replacements": ["stream.Duplex"],
+      "url": {"type": "e18e", "id": "duplexer"}
+    },
+    "duplexify": {
+      "type": "module",
+      "moduleName": "duplexify",
+      "replacements": ["stream.Duplex"],
+      "url": {"type": "e18e", "id": "duplexer"}
     },
     "encode-utf8": {
       "type": "module",

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -298,30 +298,6 @@
       "replacements": ["dlv", "dset"],
       "url": {"type": "e18e", "id": "dot-prop"}
     },
-    "duplexer": {
-      "type": "module",
-      "moduleName": "duplexer",
-      "replacements": ["stream.Duplex"],
-      "url": {"type": "e18e", "id": "duplexer"}
-    },
-    "duplexer2": {
-      "type": "module",
-      "moduleName": "duplexer2",
-      "replacements": ["stream.Duplex"],
-      "url": {"type": "e18e", "id": "duplexer"}
-    },
-    "duplexer3": {
-      "type": "module",
-      "moduleName": "duplexer3",
-      "replacements": ["stream.Duplex"],
-      "url": {"type": "e18e", "id": "duplexer"}
-    },
-    "duplexify": {
-      "type": "module",
-      "moduleName": "duplexify",
-      "replacements": ["stream.Duplex"],
-      "url": {"type": "e18e", "id": "duplexer"}
-    },
     "emoji-regex": {
       "type": "module",
       "moduleName": "emoji-regex",
@@ -3667,12 +3643,6 @@
       "id": "sortobject",
       "type": "documented",
       "replacementModule": "sortobject"
-    },
-    "stream.Duplex": {
-      "id": "stream.Duplex",
-      "type": "native",
-      "url": {"type": "node", "id": "api/stream.html#class-streamduplex"},
-      "nodeFeatureId": {"moduleName": "node:stream", "exportName": "Duplex"}
     },
     "streams": {
       "id": "streams",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Moves `stream.Duplex` replacements to the native manifest
