### PR TITLE
feat: add istanbul-lib-coverage to preferred replacements

### DIFF
--- a/docs/modules/istanbul-lib-coverage.md
+++ b/docs/modules/istanbul-lib-coverage.md
@@ -1,24 +1,18 @@
 ---
-description: Replace the unmaintained istanbul-lib-coverage package with the maintained @vitest/istanbul-lib-coverage fork
+description: Modern alternatives to the istanbul-lib-coverage package
 ---
 
 # Replacements for `istanbul-lib-coverage`
 
-`istanbul-lib-coverage` is no longer maintained. The Vitest team publishes
-[`@vitest/istanbul-lib-coverage`](https://www.npmjs.com/package/@vitest/istanbul-lib-coverage),
-a maintained fork that keeps the same API, so migrating is usually just a matter
-of changing the import.
-
-Compared to the original it is:
-
-- Actively maintained
-- Shipped as ESM instead of CommonJS only
-- Bundled with its own type definitions, so you no longer need `@types/istanbul-lib-coverage`
+`istanbul-lib-coverage` is no longer maintained.
 
 ## `@vitest/istanbul-lib-coverage`
 
-The exported functions and classes keep their existing names, so the only change
-in most projects is the package you import from.
+The Vitest team publishes
+[`@vitest/istanbul-lib-coverage`](https://www.npmjs.com/package/@vitest/istanbul-lib-coverage),
+a maintained fork that keeps the same API. The exported functions and classes
+keep their existing names, so in most projects the only change is the package
+you import from.
 
 ```ts
 import { createCoverageMap } from 'istanbul-lib-coverage' // [!code --]
@@ -26,6 +20,17 @@ import { createCoverageMap } from '@vitest/istanbul-lib-coverage' // [!code ++]
 
 const map = createCoverageMap(coverageData)
 ```
+
+Compared to the original it is:
+
+- Actively maintained
+- Shipped as ESM instead of CommonJS only
+- Bundled with its own type definitions, so you no longer need `@types/istanbul-lib-coverage`
+
+> [!NOTE]
+> The fork is ESM-only and sets `engines.node` to `>=22`, so switching is a
+> larger jump than a plain import swap for projects still on CommonJS or an
+> older Node version.
 
 If you also depend on `@types/istanbul-lib-coverage` only for this package, you
 can drop it once you migrate, since the fork ships its own types.

--- a/docs/modules/istanbul-lib-coverage.md
+++ b/docs/modules/istanbul-lib-coverage.md
@@ -1,0 +1,31 @@
+---
+description: Replace the unmaintained istanbul-lib-coverage package with the maintained @vitest/istanbul-lib-coverage fork
+---
+
+# Replacements for `istanbul-lib-coverage`
+
+`istanbul-lib-coverage` is no longer maintained. The Vitest team publishes
+[`@vitest/istanbul-lib-coverage`](https://www.npmjs.com/package/@vitest/istanbul-lib-coverage),
+a maintained fork that keeps the same API, so migrating is usually just a matter
+of changing the import.
+
+Compared to the original it is:
+
+- Actively maintained
+- Shipped as ESM instead of CommonJS only
+- Bundled with its own type definitions, so you no longer need `@types/istanbul-lib-coverage`
+
+## `@vitest/istanbul-lib-coverage`
+
+The exported functions and classes keep their existing names, so the only change
+in most projects is the package you import from.
+
+```ts
+import { createCoverageMap } from 'istanbul-lib-coverage' // [!code --]
+import { createCoverageMap } from '@vitest/istanbul-lib-coverage' // [!code ++]
+
+const map = createCoverageMap(coverageData)
+```
+
+If you also depend on `@types/istanbul-lib-coverage` only for this package, you
+can drop it once you migrate, since the fork ships its own types.

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -572,6 +572,12 @@
       "replacements": ["fetch", "ofetch", "ky"],
       "url": {"type": "e18e", "id": "fetch"}
     },
+    "istanbul-lib-coverage": {
+      "type": "module",
+      "moduleName": "istanbul-lib-coverage",
+      "replacements": ["@vitest/istanbul-lib-coverage"],
+      "url": {"type": "e18e", "id": "istanbul-lib-coverage"}
+    },
     "jquery": {
       "type": "module",
       "moduleName": "jquery",
@@ -2955,6 +2961,11 @@
       "id": "@vitest/eslint-plugin",
       "type": "documented",
       "replacementModule": "@vitest/eslint-plugin"
+    },
+    "@vitest/istanbul-lib-coverage": {
+      "id": "@vitest/istanbul-lib-coverage",
+      "type": "documented",
+      "replacementModule": "@vitest/istanbul-lib-coverage"
     },
     "@xmldom/xmldom": {
       "id": "@xmldom/xmldom",


### PR DESCRIPTION
Adds `istanbul-lib-coverage` to the preferred manifest, pointing at the maintained `@vitest/istanbul-lib-coverage` fork, since the original is no longer maintained.

The fork keeps the same API so migrating is mostly just swapping the import, and it ships as ESM with its own types. I added a docs page covering that.

Closes #993
