### PR TITLE
chore: simplify `typeof` examples for primitives

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -148,7 +148,7 @@
       "id": "snippet::is-bigint",
       "type": "simple",
       "description": "You can use `typeof` to check if a value is a bigint.",
-      "example": "const isBigInt = (value) => typeof value === \"bigint\";"
+      "example": "typeof value === \"bigint\";"
     },
     "snippet::is-boolean": {
       "id": "snippet::is-boolean",
@@ -310,13 +310,13 @@
       "id": "snippet::is-string",
       "type": "simple",
       "description": "You can use `typeof` to check if a value is a string.",
-      "example": "const isString = (value) => typeof value === \"string\";"
+      "example": "typeof value === \"string\";"
     },
     "snippet::is-symbol": {
       "id": "snippet::is-symbol",
       "type": "simple",
       "description": "You can use `typeof` to check if a value is a symbol.",
-      "example": "const isSymbol = (value) => typeof value === \"symbol\";"
+      "example": "typeof value === \"symbol\";"
     },
     "snippet::is-touch-device": {
       "id": "snippet::is-touch-device",

--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -148,7 +148,7 @@
       "id": "snippet::is-bigint",
       "type": "simple",
       "description": "You can use `typeof` to check if a value is a bigint.",
-      "example": "const isString = (value) => typeof value === \"bigint\";"
+      "example": "const isBigInt = (value) => typeof value === \"bigint\";"
     },
     "snippet::is-boolean": {
       "id": "snippet::is-boolean",


### PR DESCRIPTION
### 🔗 Linked issue

None


### 📚 Description

Some like `is-undefined` already do it that way

This makes them all the same for primitives
