### PR TITLE
feat: add `mkdirp-classic` to native replacements

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -1820,6 +1820,12 @@
       "url": {"type": "node", "id": "api/fs.html#promises-api"},
       "nodeFeatureId": {"moduleName": "fs"}
     },
+    "fs.promises.mkdir": {
+      "id": "fs.promises.mkdir",
+      "type": "native",
+      "nodeFeatureId": {"moduleName": "node:fs", "exportName": "mkdir"},
+      "url": {"type": "node", "id": "api/fs.html#fspromisesmkdirpath-options"}
+    },
     "fs.promises.rm": {
       "id": "fs.promises.rm",
       "type": "native",
@@ -3027,6 +3033,12 @@
       "moduleName": "long",
       "replacements": ["BigInt"]
     },
+    "make-dir": {
+      "type": "module",
+      "moduleName": "make-dir",
+      "replacements": ["fs.promises.mkdir"],
+      "url": {"type": "e18e", "id": "mkdirp"}
+    },
     "math-intrinsics": {
       "type": "module",
       "moduleName": "math-intrinsics",
@@ -3097,6 +3109,18 @@
       "moduleName": "micromatch",
       "replacements": ["path.matchesGlob", "picomatch", "zeptomatch"],
       "url": {"type": "e18e", "id": "micromatch"}
+    },
+    "mkdirp": {
+      "type": "module",
+      "moduleName": "mkdirp",
+      "replacements": ["fs.promises.mkdir"],
+      "url": {"type": "e18e", "id": "mkdirp"}
+    },
+    "mkdirp-classic": {
+      "type": "module",
+      "moduleName": "mkdirp-classic",
+      "replacements": ["fs.promises.mkdir"],
+      "url": {"type": "e18e", "id": "mkdirp"}
     },
     "native-promise-only": {
       "type": "module",

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2306,12 +2306,6 @@
       "replacements": ["lodash-underscore", "es-toolkit"],
       "url": {"type": "e18e", "id": "lodash-underscore"}
     },
-    "make-dir": {
-      "type": "module",
-      "moduleName": "make-dir",
-      "replacements": ["fs.promises.mkdir"],
-      "url": {"type": "e18e", "id": "mkdirp"}
-    },
     "materialize-css": {
       "type": "module",
       "moduleName": "materialize-css",
@@ -2347,12 +2341,6 @@
       "moduleName": "mississippi",
       "replacements": ["node:stream"],
       "url": {"type": "e18e", "id": "mississippi"}
-    },
-    "mkdirp": {
-      "type": "module",
-      "moduleName": "mkdirp",
-      "replacements": ["fs.promises.mkdir"],
-      "url": {"type": "e18e", "id": "mkdirp"}
     },
     "mktemp": {
       "type": "module",
@@ -3343,12 +3331,6 @@
       "type": "native",
       "nodeFeatureId": {"moduleName": "node:fs", "exportName": "glob"},
       "url": {"type": "node", "id": "api/fs.html#fspromisesglobpattern-options"}
-    },
-    "fs.promises.mkdir": {
-      "id": "fs.promises.mkdir",
-      "type": "native",
-      "nodeFeatureId": {"moduleName": "node:fs", "exportName": "mkdir"},
-      "url": {"type": "node", "id": "api/fs.html#fspromisesmkdirpath-options"}
     },
     "fs.promises.mkdtemp": {
       "id": "fs.promises.mkdtemp",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1002


### 📚 Description


Moved `fs.promises.mkdir` to native manifest

Added `mkdirp-classic` to native replacements
