### PR TITLE
feat: add `simple-concat` to native replacements

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2074,6 +2074,12 @@
       "url": {"type": "node", "id": "api/stream.html#streamcomposestreams"},
       "nodeFeatureId": {"moduleName": "node:stream", "exportName": "compose"}
     },
+    "streamConsumers": {
+      "id": "streamConsumers",
+      "type": "native",
+      "url": {"type": "node", "id": "api/webstreams.html#utility-consumers"},
+      "nodeFeatureId": {"moduleName": "node:stream/consumers"}
+    },
     "string_decoder": {
       "id": "string_decoder",
       "type": "native",
@@ -2433,7 +2439,7 @@
     "concat-stream": {
       "type": "module",
       "moduleName": "concat-stream",
-      "replacements": ["node:stream"],
+      "replacements": ["streamConsumers"],
       "url": {"type": "e18e", "id": "concat-stream"}
     },
     "crc": {
@@ -3412,7 +3418,7 @@
     "simple-concat": {
       "type": "module",
       "moduleName": "simple-concat",
-      "replacements": ["node:stream"],
+      "replacements": ["streamConsumers"],
       "url": {"type": "e18e", "id": "concat-stream"}
     },
     "starts-with": {

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2430,6 +2430,12 @@
       "moduleName": "concat-map",
       "replacements": ["Array.prototype.flatMap"]
     },
+    "concat-stream": {
+      "type": "module",
+      "moduleName": "concat-stream",
+      "replacements": ["node:stream"],
+      "url": {"type": "e18e", "id": "concat-stream"}
+    },
     "crc": {
       "type": "module",
       "moduleName": "crc",
@@ -3402,6 +3408,12 @@
       "type": "module",
       "moduleName": "setprototypeof",
       "replacements": ["Object.setPrototypeOf"]
+    },
+    "simple-concat": {
+      "type": "module",
+      "moduleName": "simple-concat",
+      "replacements": ["node:stream"],
+      "url": {"type": "e18e", "id": "concat-stream"}
     },
     "starts-with": {
       "type": "module",

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -168,12 +168,6 @@
       "replacements": ["util.styleText", "picocolors", "ansis"],
       "url": {"type": "e18e", "id": "chalk"}
     },
-    "concat-stream": {
-      "type": "module",
-      "moduleName": "concat-stream",
-      "replacements": ["node:stream"],
-      "url": {"type": "e18e", "id": "concat-stream"}
-    },
     "copy-paste": {
       "type": "module",
       "moduleName": "copy-paste",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1058


### 📚 Description

add `simple-concat` to native replacements

Moved `concat-stream` to native manifest