### PR TITLE
feat: add `deepmerge` to replacements

### DIFF
--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -256,6 +256,12 @@
       "replacements": ["dequal", "util.isDeepStrictEqual", "Bun.deepEquals"],
       "url": {"type": "e18e", "id": "deep-equal"}
     },
+    "deepmerge": {
+      "type": "module",
+      "moduleName": "deepmerge",
+      "replacements": ["defu", "@fastify/deepmerge"],
+      "url": {"type": "e18e", "id": "deep-merge"}
+    },
     "depcheck": {
       "type": "module",
       "moduleName": "depcheck",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1075

### 📚 Description

Adds `deepmerge` to the preferred replacements manifest, pointing to the existing `defu` and `@fastify/deepmerge` entries and the existing deep-merge migration guide.

Both alternatives were accepted in #1075. Their APIs are not drop-in replacements for every use case, so the existing guide documents the migration differences.

Validated with `pnpm lint` and `pnpm build`.
