### PR TITLE
feat(micro-utilities): add iterate-object to replacements

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -444,6 +444,12 @@
       "description": "You can use `Object.fromEntries` with `Object.entries` to invert keys and values.",
       "example": "Object.fromEntries(Object.entries(object).map(([k, v]) => [v, k]))"
     },
+    "snippet::object-iterate": {
+      "id": "snippet::object-iterate",
+      "type": "simple",
+      "description": "You can use a `for...of` loop over `Object.entries` to iterate an object's own enumerable properties, and `break` to stop early.",
+      "example": "for (const [key, value] of Object.entries(obj)) {\n  if (key === 'stop') break\n  // do something\n}\n// Or for arrays\nfor (const [index, value] of arr.entries()) {\n  // do something\n}"
+    },
     "snippet::object-map": {
       "id": "snippet::object-map",
       "type": "simple",
@@ -936,6 +942,11 @@
       "type": "module",
       "moduleName": "isstream",
       "replacements": ["snippet::is-stream"]
+    },
+    "iterate-object": {
+      "type": "module",
+      "moduleName": "iterate-object",
+      "replacements": ["snippet::object-iterate"]
     },
     "js-base64": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

closes: #1074
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

adds `iterate-object` to the micro-utilities manifest

kept this as its own snippet rather than mapping it to `snippet::for-own`, since that one uses `Object.keys().forEach` which can't break early. `iterate-object` stops the loop when the callback returns `false`, and also handles arrays.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
