### PR TITLE
feat(micro-utilities): add is-property to replacements

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -228,6 +228,12 @@
       "description": "You can check first three bytes of a buffer to detect if it is a gzip file.",
       "example": "function isGzip(buf) {\n  if (buf.length < 3) return false;\n  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8;\n}"
     },
+    "snippet::is-identifier-name": {
+      "id": "snippet::is-identifier-name",
+      "type": "simple",
+      "description": "You can test a string against the `ID_Start` and `ID_Continue` Unicode properties to check whether it is a valid identifier name, and so usable as an unquoted property.",
+      "example": "const identifierNameRE = /^[$_\\p{ID_Start}][$\\u200c\\u200d\\p{ID_Continue}]*$/u;\n\nconst isProperty = (str) => identifierNameRE.test(str);"
+    },
     "snippet::is-in-ssh": {
       "id": "snippet::is-in-ssh",
       "type": "simple",
@@ -890,6 +896,11 @@
       "type": "module",
       "moduleName": "is-primitive",
       "replacements": ["snippet::is-primitve"]
+    },
+    "is-property": {
+      "type": "module",
+      "moduleName": "is-property",
+      "replacements": ["snippet::is-identifier-name"]
     },
     "is-regex": {
       "type": "module",

--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -232,7 +232,7 @@
       "id": "snippet::is-identifier-name",
       "type": "simple",
       "description": "You can test a string against the `ID_Start` and `ID_Continue` Unicode properties to check whether it is a valid identifier name, and so usable as an unquoted property.",
-      "example": "const identifierNameRE = /^[$_\\p{ID_Start}][$\\u200c\\u200d\\p{ID_Continue}]*$/u;\n\nconst isProperty = (str) => identifierNameRE.test(str);"
+      "example": "const isProperty = (str) => /^[$_\\p{ID_Start}][$\\p{ID_Continue}]*$/u.test(str)"
     },
     "snippet::is-in-ssh": {
       "id": "snippet::is-in-ssh",


### PR DESCRIPTION
### 🔗 Linked issue

closes: #1025
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

adds `is-property` to the micro-utilities manifest
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
