### PR TITLE
feat(native): add is-path-inside and is-path-in-cwd to replacements

### DIFF
--- a/docs/modules/is-path-in-cwd.md
+++ b/docs/modules/is-path-in-cwd.md
@@ -1,0 +1,13 @@
+---
+description: Native alternatives to the is-path-in-cwd package for checking whether a path is inside the current working directory
+---
+
+# Replacements for `is-path-in-cwd`
+
+`is-path-in-cwd` is `is-path-inside` with `process.cwd()` as the parent, so use the [`is-path-inside` replacement](./is-path-inside.md) and pass the working directory yourself.
+
+```ts
+import isPathInCwd from 'is-path-in-cwd' // [!code --]
+isPathInCwd(p) // [!code --]
+isPathInside(p, process.cwd()) // [!code ++]
+```

--- a/docs/modules/is-path-in-cwd.md
+++ b/docs/modules/is-path-in-cwd.md
@@ -7,7 +7,17 @@ description: Native alternatives to the is-path-in-cwd package for checking whet
 `is-path-in-cwd` is `is-path-inside` with `process.cwd()` as the parent, so use the [`is-path-inside` replacement](./is-path-inside.md) and pass the working directory yourself.
 
 ```ts
-import isPathInCwd from 'is-path-in-cwd' // [!code --]
-isPathInCwd(p) // [!code --]
-isPathInside(p, process.cwd()) // [!code ++]
+import path from 'node:path'
+
+const isPathInside = (childPath, parentPath) => {
+  const relation = path.relative(parentPath, childPath)
+  return Boolean(
+    relation &&
+    relation !== '..' &&
+    !relation.startsWith(`..${path.sep}`) &&
+    relation !== path.resolve(childPath)
+  )
+}
+
+const isPathInCwd = (p) => isPathInside(p, process.cwd())
 ```

--- a/docs/modules/is-path-inside.md
+++ b/docs/modules/is-path-inside.md
@@ -1,0 +1,27 @@
+---
+description: Native alternatives to the is-path-inside package for checking whether one path is inside another
+---
+
+# Replacements for `is-path-inside`
+
+[`path.relative`](https://nodejs.org/api/path.html#pathrelativefrom-to) gives you the route from the parent to the child. If that route is empty, or climbs out with `..`, the child is not inside the parent.
+
+The comparison against `path.resolve` catches paths on a different Windows drive, where `path.relative` returns an absolute path rather than one starting with `..`.
+
+<!-- prettier-ignore -->
+```ts
+import isPathInside from 'is-path-inside' // [!code --]
+import path from 'node:path' // [!code ++]
+
+const isPathInside = (childPath, parentPath) => { // [!code ++]
+  const relation = path.relative(parentPath, childPath) // [!code ++]
+  return Boolean( // [!code ++]
+    relation && // [!code ++]
+    relation !== '..' && // [!code ++]
+    !relation.startsWith(`..${path.sep}`) && // [!code ++]
+    relation !== path.resolve(childPath) // [!code ++]
+  ) // [!code ++]
+} // [!code ++]
+```
+
+Note that this is purely a string comparison. Neither the package nor the replacement touches the filesystem, so symlinks are not resolved.

--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2022,6 +2022,12 @@
       "url": {"type": "node", "id": "api/path.html#pathparsepath"},
       "nodeFeatureId": {"moduleName": "path", "exportName": "parse"}
     },
+    "path.relative": {
+      "id": "path.relative",
+      "type": "native",
+      "url": {"type": "node", "id": "api/path.html#pathrelativefrom-to"},
+      "nodeFeatureId": {"moduleName": "path", "exportName": "relative"}
+    },
     "picomatch": {
       "id": "picomatch",
       "type": "documented",
@@ -2913,6 +2919,18 @@
       "type": "module",
       "moduleName": "is-nan",
       "replacements": ["Number.isNaN"]
+    },
+    "is-path-in-cwd": {
+      "type": "module",
+      "moduleName": "is-path-in-cwd",
+      "replacements": ["path.relative"],
+      "url": {"type": "e18e", "id": "is-path-in-cwd"}
+    },
+    "is-path-inside": {
+      "type": "module",
+      "moduleName": "is-path-inside",
+      "replacements": ["path.relative"],
+      "url": {"type": "e18e", "id": "is-path-inside"}
     },
     "is-url-superb": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

closes: #1009
closes: #1022
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

adds `is-path-inside` and `is-path-in-cwd` to the native manifest
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
