### PR TITLE
feat(micro-utilities): add path-root to replacements

### DIFF
--- a/docs/modules/path-root.md
+++ b/docs/modules/path-root.md
@@ -1,0 +1,38 @@
+---
+description: Native alternatives to the path-root and path-root-regex packages for reading the root of a path
+---
+
+# Replacements for `path-root` / `path-root-regex`
+
+`path-root` returns the root of a path, `/` for an absolute path and an empty string for a relative one. `path-root-regex` is the regular expression behind it, and is only ever pulled in as a dependency of `path-root`.
+
+## In Node.js
+
+[`parse`](https://nodejs.org/api/path.html#pathparsepath) already exposes this as its `root` property.
+
+```ts
+import pathRoot from 'path-root' // [!code --]
+import { parse } from 'node:path' // [!code ++]
+
+pathRoot(filepath) // [!code --]
+parse(filepath).root // [!code ++]
+```
+
+`parse` follows the platform it runs on, so on Linux and macOS it reads `\` and `C:` as ordinary filename characters where `path-root` treated them as roots, and it reads a leading `//` as a plain root rather than a UNC server and share. Reach for `win32.parse` if you actually need to parse Windows paths on a POSIX host.
+
+## In the browser
+
+`node:path` is not available, so keep the regular expression. This is the one `path-root-regex` returns.
+
+<!-- prettier-ignore -->
+```ts
+import pathRootRegex from 'path-root-regex' // [!code --]
+const ROOT_RE = /^([a-zA-Z]:|[\\/]{2}[^\\/]+[\\/]+[^\\/]+)?([\\/])?/ // [!code ++]
+
+const pathRoot = (filepath) => { // [!code ++]
+  if (typeof filepath !== 'string') throw new TypeError('expected a string') // [!code ++]
+  return ROOT_RE.exec(filepath)[0] // [!code ++]
+} // [!code ++]
+```
+
+Keep the type check. Without it the regex coerces its argument, so a non-string returns an empty string instead of throwing the way `path-root` does.

--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -486,6 +486,12 @@
       "description": "You can use `Object.keys` with `Array.prototype.findLast` to find the case-insensitive `PATH` environment variable key.",
       "example": "const pathKey = Object.keys(process.env).findLast((k) => k.toUpperCase() === 'PATH') ?? 'PATH';"
     },
+    "snippet::path-root": {
+      "id": "snippet::path-root",
+      "type": "simple",
+      "description": "You can use `parse` from `node:path` and read its `root` property to get the root of a path.",
+      "example": "import { parse } from 'node:path'\n\nconst pathRoot = (filepath) => parse(filepath).root"
+    },
     "snippet::regexp-copy": {
       "id": "snippet::regexp-copy",
       "type": "simple",
@@ -1165,6 +1171,18 @@
       "type": "module",
       "moduleName": "path-name",
       "replacements": ["snippet::path-key"]
+    },
+    "path-root": {
+      "type": "module",
+      "moduleName": "path-root",
+      "replacements": ["snippet::path-root"],
+      "url": {"type": "e18e", "id": "path-root"}
+    },
+    "path-root-regex": {
+      "type": "module",
+      "moduleName": "path-root-regex",
+      "replacements": ["snippet::path-root"],
+      "url": {"type": "e18e", "id": "path-root"}
     },
     "reduce-object": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

closes: #1016
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

adds `path-root` and `path-root-regex` to the micro-utilities manifest

first doc page on a micro-utilities mapping, going off james' suggestion on the issue to explain the node vs browser split.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
