### PR TITLE
feat: add tar to replacements

### DIFF
--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2622,6 +2622,12 @@
       "replacements": ["util.stripVTControlCharacters", "Bun.stripANSI"],
       "url": {"type": "e18e", "id": "strip-ansi"}
     },
+    "tar": {
+      "type": "module",
+      "moduleName": "tar",
+      "replacements": ["modern-tar"],
+      "url": {"type": "e18e", "id": "tar-fs"}
+    },
     "tar-fs": {
       "type": "module",
       "moduleName": "tar-fs",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1093

### 📚 Description

Adds `tar` to the preferred replacements manifest and maps it to `modern-tar`, consistent with the existing `tar-fs` and `tar-stream` entries.