### PR TITLE
feat: add util-arity replacement

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -1298,6 +1298,11 @@
       "moduleName": "upper-case-first",
       "replacements": ["snippet::uppercase-first-character"]
     },
+    "util-arity": {
+      "type": "module",
+      "moduleName": "util-arity",
+      "replacements": ["snippet::set-function-length"]
+    },
     "validate.io-function": {
       "type": "module",
       "moduleName": "validate.io-function",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1057

### 📚 Description

Adds `util-arity` to the micro-utilities manifest and reuses the existing function-length snippet.