### PR TITLE
feat(micro-utilities): add is-dotfile to replacements

### DIFF
--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -707,11 +707,6 @@
       "moduleName": "defined",
       "replacements": ["snippet::find-first-defined"]
     },
-    "dotfile-regex": {
-      "type": "module",
-      "moduleName": "dotfile-regex",
-      "replacements": ["snippet::is-dotfile"]
-    },
     "es-get-iterator": {
       "type": "module",
       "moduleName": "es-get-iterator",

--- a/manifests/micro-utilities.json
+++ b/manifests/micro-utilities.json
@@ -204,6 +204,12 @@
       "description": "You can call `isDirectory()` on the result of `stat` from `node:fs/promises`, or of `statSync` from `node:fs`, treating an `ENOENT` error as `false`.",
       "example": "import { stat } from 'node:fs/promises'\n\nconst isDirectory = async (filepath) => {\n  try {\n    return (await stat(filepath)).isDirectory()\n  } catch (err) {\n    if (err.code === 'ENOENT') return false\n    throw err\n  }\n}"
     },
+    "snippet::is-dotfile": {
+      "id": "snippet::is-dotfile",
+      "type": "simple",
+      "description": "You can test whether a path ends in a dotfile such as `.gitignore` using a regular expression.",
+      "example": "const isDotfile = (str) => /(?:\\/|^)\\.[^/.][^/]*$/.test(str)"
+    },
     "snippet::is-electron": {
       "id": "snippet::is-electron",
       "type": "simple",
@@ -701,6 +707,11 @@
       "moduleName": "defined",
       "replacements": ["snippet::find-first-defined"]
     },
+    "dotfile-regex": {
+      "type": "module",
+      "moduleName": "dotfile-regex",
+      "replacements": ["snippet::is-dotfile"]
+    },
     "es-get-iterator": {
       "type": "module",
       "moduleName": "es-get-iterator",
@@ -800,6 +811,11 @@
       "type": "module",
       "moduleName": "is-directory",
       "replacements": ["snippet::is-directory"]
+    },
+    "is-dotfile": {
+      "type": "module",
+      "moduleName": "is-dotfile",
+      "replacements": ["snippet::is-dotfile"]
     },
     "is-electron": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

closes: #1006

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

adds `is-dotfile` and `dotfile-regex` to the micro-utilities manifest

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
