### PR TITLE
feat(preferred): add wait-for-expect replacements

### DIFF
--- a/docs/modules/wait-for-expect.md
+++ b/docs/modules/wait-for-expect.md
@@ -1,0 +1,51 @@
+---
+description: Replace wait-for-expect with built-in assertion retries in Vitest or node:test
+---
+
+# Replacements for `wait-for-expect`
+
+If your tests already use Vitest or `node:test`, you can replace `wait-for-expect` with the runner's built-in assertion retries.
+
+Both APIs retry callbacks that throw or return a rejected promise until they succeed or time out. Keep the assertion inside the callback and await the result; returning `false` alone does not trigger a retry.
+
+The arguments change from `waitForExpect(callback, timeout, interval)` to `vi.waitFor(callback, { timeout, interval })` or `t.waitFor(callback, { timeout, interval })`. The examples below preserve `wait-for-expect`'s default settings of a 4,500 ms timeout and 50 ms interval. Both runners otherwise default to a 1,000 ms timeout and 50 ms interval. Matching these settings does not guarantee identical scheduling or timeout behavior.
+
+## `vitest`
+
+[`vi.waitFor()`](https://vitest.dev/api/vi.html#vi-waitfor) is available since Vitest 0.34.5 and accepts synchronous or asynchronous assertion callbacks.
+
+```ts
+import waitForExpect from 'wait-for-expect' // [!code --]
+import { expect, test } from 'vitest' // [!code --]
+import { expect, test, vi } from 'vitest' // [!code ++]
+
+test('service becomes ready', async () => {
+  const checkReady = async () => {
+    expect(await service.isReady()).toBe(true)
+  }
+
+  await waitForExpect(checkReady, 4500, 50) // [!code --]
+  await vi.waitFor(checkReady, { timeout: 4500, interval: 50 }) // [!code ++]
+})
+```
+
+If you use `vi.useFakeTimers()`, `vi.waitFor()` automatically advances fake timers by the polling interval on each check. Review tests that previously advanced timers manually.
+
+## `node:test`
+
+[`t.waitFor()`](https://nodejs.org/api/test.html#contextwaitforcondition-options) is available on the test context since Node.js 22.14.0 and 23.7.0. It also accepts synchronous or asynchronous assertion callbacks.
+
+```ts
+import waitForExpect from 'wait-for-expect' // [!code --]
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+test('service becomes ready', async (t) => {
+  const checkReady = async () => {
+    assert.equal(await service.isReady(), true)
+  }
+
+  await waitForExpect(checkReady, 4500, 50) // [!code --]
+  await t.waitFor(checkReady, { timeout: 4500, interval: 50 }) // [!code ++]
+})
+```

--- a/manifests/preferred.json
+++ b/manifests/preferred.json
@@ -2796,6 +2796,12 @@
       "replacements": ["vue-markdown-render"],
       "url": {"type": "e18e", "id": "vue3-markdown-it"}
     },
+    "wait-for-expect": {
+      "type": "module",
+      "moduleName": "wait-for-expect",
+      "replacements": ["node:test", "vitest"],
+      "url": {"type": "e18e", "id": "wait-for-expect"}
+    },
     "wellknown": {
       "type": "module",
       "moduleName": "wellknown",


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1099.

### 📚 Description

Implementation assisted by AI tools.

Add `wait-for-expect` to the preferred manifest with the existing Vitest and `node:test` replacements. Projects using either runner can remove the extra dependency.

The guide now keeps the introduction brief and puts migration details in each runner’s section. Examples, minimum versions, assertion retries, and Vitest fake-timer guidance are preserved.

### Validation

Local build, lint, adoption validation, and `git diff --check` passed on Node 22.22.2 with pnpm 10.33.3. Both example blocks and all remaining guide content are unchanged.

CI passed the [four Node build/lint jobs](https://github.com/e18e/module-replacements/actions/runs/35245895779) and [adoption validation](https://github.com/e18e/module-replacements/actions/runs/35245895766) for `498b55b`.

Reviewed with the help of AI.
