### PR TITLE
feat(native): add w3c-hr-time to replacements

### DIFF
--- a/manifests/native.json
+++ b/manifests/native.json
@@ -2035,6 +2035,15 @@
       "url": {"type": "node", "id": "api/path.html#pathrelativefrom-to"},
       "nodeFeatureId": {"moduleName": "path", "exportName": "relative"}
     },
+    "performance": {
+      "id": "performance",
+      "type": "native",
+      "url": {"type": "mdn", "id": "Web/API/Performance"},
+      "webFeatureId": {
+        "featureId": "performance",
+        "compatKey": "api.Performance"
+      }
+    },
     "picomatch": {
       "id": "picomatch",
       "type": "documented",
@@ -3741,6 +3750,11 @@
       "type": "module",
       "moduleName": "validate.io-array",
       "replacements": ["Array.isArray"]
+    },
+    "w3c-hr-time": {
+      "type": "module",
+      "moduleName": "w3c-hr-time",
+      "replacements": ["performance"]
     },
     "weak-map": {
       "type": "module",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

closes: #1104

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

adds `w3c-hr-time` to the native manifest

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to module-replacements!
----------------------------------------------------------------------->
